### PR TITLE
Fix call to end/done after eachSeries

### DIFF
--- a/tasks/analyze-css.js
+++ b/tasks/analyze-css.js
@@ -96,7 +96,7 @@ module.exports = function (grunt) {
             grunt.log.ok('Done.'); 
         }
         grunt.log.writeln();
-        return hasErrors;
+        done();
     };
     
     var getChalks = function (value) {
@@ -183,6 +183,6 @@ module.exports = function (grunt) {
                nextFileObj();
            });
         });
-    }, end, done);
+    }, end);
 });
 };


### PR DESCRIPTION
The grunt done() function was never called. 
I often use "time-grunt" to have some nice execution time of tasks, and it was never called after analyze-css...
